### PR TITLE
Add option of passing username as argument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "steam-time-played"
-version = "0.1.0"
-authors = ["flauntingspade4 <48335751+flauntingspade4@users.noreply.github.com>"]
+version = "0.1.1"
+authors = ["flauntingspade4 <48335751+flauntingspade4@users.noreply.github.com>","w-henderson <william-henderson@outlook.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# steam-time-played
+# Steam Time Played
 
-A tool to find the amount of time played by players for steam
+A simple tool to find the total playtime of any user on Steam.
 
-- The player's profile must be public
-- You must have an api key from valve, found [here](https://steamcommunity.com/dev/apikey) saved in a file called '.token' in the same folder
+### Usage
+Pass the username as a command-line argument, or enter it when requested by the program if you don't.
+
+### Requirements
+- The specified player's profile must be public
+- You must have a [Steam Web API Key](https://steamcommunity.com/dev/apikey) stored in a file called `.token`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,16 @@
 use serde::Deserialize;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let token = std::fs::read_to_string(".token")?;
-    let mut name = String::new();
-    std::io::stdin().read_line(&mut name)?;
-    name = String::from(name.trim());
+
+    let mut args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+      let mut input_name = String::new();
+      println!("Enter Steam username: ");
+      std::io::stdin().read_line(&mut input_name)?;
+      input_name = String::from(input_name.trim());
+      args.push(input_name);
+    }
+    let ref name: String = args[1];
     let id;
     if name.len() == 17 && only_nums(&name) {
         id = name.parse::<u128>().unwrap();


### PR DESCRIPTION
If the username is not specified as a command-line argument, fall back to inputting it like before.